### PR TITLE
Fix oscillator gain routing in melody training

### DIFF
--- a/melody_training.html
+++ b/melody_training.html
@@ -397,8 +397,8 @@
     thirdGain.connect(mainGain);
 
     const fourthGain = audioCtx.createGain();
-    thirdGain.gain.value = 0.03;
-    thirdGain.connect(mainGain);
+    fourthGain.gain.value = 0.03;
+    fourthGain.connect(mainGain);
 
     // Fundamental
     const oscFund = audioCtx.createOscillator();


### PR DESCRIPTION
## Summary
- correct gain settings for fourth partial in `playOneNote`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68590cb619488333a8598cea40b6cf08