### PR TITLE
Enable hold-to-play for chord training

### DIFF
--- a/chord_training.html
+++ b/chord_training.html
@@ -184,7 +184,7 @@
 
   // Fade times for chord playback (seconds)
   const FADE_IN_TIME  = 0.01;
-  const FADE_OUT_TIME = 0.3;
+  const FADE_OUT_TIME = 0.7;
 
   // DOM elements
   const keyboardDiv       = document.getElementById("keyboard");

--- a/chord_training.html
+++ b/chord_training.html
@@ -179,6 +179,10 @@
   let selectedKeys = new Set();  // A set of indices that the user has selected
   let lowestChordIndex = null;   // The index (into currentNotes) of the chord's lowest note
 
+  let activeAudioCtx = null;
+  let activeGain = null;
+  let activeOscillators = [];
+
   // DOM elements
   const keyboardDiv       = document.getElementById("keyboard");
   const lowestNoteSelect  = document.getElementById("lowestNoteSelect");
@@ -357,80 +361,94 @@
   }
 
   //------------------------------------------------------------
-  // Play multiple frequencies simultaneously as a chord
+  // Start/stop playback for a set of frequencies
   //------------------------------------------------------------
-  function playChordFrequencies(frequencies, duration = 1.0) {
+  function startChordPlayback(frequencies) {
     if (!frequencies || frequencies.length === 0) return;
-    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    const now = audioCtx.currentTime;
-    const stopTime = now + duration;
+    stopChordPlayback();
 
-    // Master gain for fade in/out
-    const masterGain = audioCtx.createGain();
-    masterGain.connect(audioCtx.destination);
-    masterGain.gain.setValueAtTime(0, now);
-    masterGain.gain.linearRampToValueAtTime(1, now + 0.01);
-    masterGain.gain.linearRampToValueAtTime(0, stopTime - 0.01);
+    activeAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const now = activeAudioCtx.currentTime;
 
+    activeGain = activeAudioCtx.createGain();
+    activeGain.connect(activeAudioCtx.destination);
+    activeGain.gain.setValueAtTime(0, now);
+    activeGain.gain.linearRampToValueAtTime(1, now + 0.01);
+
+    activeOscillators = [];
     frequencies.forEach(freq => {
-      // Gains for partials
-      const fGain = audioCtx.createGain();
+      const fGain = activeAudioCtx.createGain();
       fGain.gain.value = 0.12;
-      fGain.connect(masterGain);
+      fGain.connect(activeGain);
 
-      const secondGain = audioCtx.createGain();
+      const secondGain = activeAudioCtx.createGain();
       secondGain.gain.value = 0.05;
-      secondGain.connect(masterGain);
+      secondGain.connect(activeGain);
 
-      const thirdGain = audioCtx.createGain();
+      const thirdGain = activeAudioCtx.createGain();
       thirdGain.gain.value = 0.03;
-      thirdGain.connect(masterGain);
+      thirdGain.connect(activeGain);
 
-      // Fundamental
-      const oscFund = audioCtx.createOscillator();
+      const oscFund = activeAudioCtx.createOscillator();
       oscFund.type = "sine";
       oscFund.frequency.value = freq;
       oscFund.connect(fGain);
       oscFund.start(now);
-      oscFund.stop(stopTime);
 
-      // 2nd harmonic
-      const osc2 = audioCtx.createOscillator();
+      const osc2 = activeAudioCtx.createOscillator();
       osc2.type = "sine";
       osc2.frequency.value = freq * 2;
       osc2.connect(secondGain);
       osc2.start(now);
-      osc2.stop(stopTime);
 
-      // 3rd harmonic
-      const osc3 = audioCtx.createOscillator();
+      const osc3 = activeAudioCtx.createOscillator();
       osc3.type = "sine";
       osc3.frequency.value = freq * 3;
       osc3.connect(thirdGain);
       osc3.start(now);
-      osc3.stop(stopTime);
+
+      activeOscillators.push(oscFund, osc2, osc3);
     });
+  }
+
+  function stopChordPlayback() {
+    if (!activeAudioCtx) return;
+    const now = activeAudioCtx.currentTime;
+    activeGain.gain.cancelScheduledValues(now);
+    activeGain.gain.setValueAtTime(activeGain.gain.value, now);
+    activeGain.gain.linearRampToValueAtTime(0, now + 0.03);
+    activeOscillators.forEach(osc => {
+      try { osc.stop(now + 0.03); } catch (e) {}
+    });
+    setTimeout(() => {
+      if (activeAudioCtx) {
+        activeAudioCtx.close();
+        activeAudioCtx = null;
+        activeGain = null;
+        activeOscillators = [];
+      }
+    }, 60);
   }
 
   //------------------------------------------------------------
   // Play the generated chord (all notes simultaneously)
   //------------------------------------------------------------
-  function playGeneratedChord() {
+  function startGeneratedChord() {
     if (!randomChord || randomChord.length === 0) return;
     const freqs = randomChord.map(obj => obj.freq);
-    playChordFrequencies(freqs, 1.5);
+    startChordPlayback(freqs);
   }
 
   //------------------------------------------------------------
   // Play the user's currently selected notes
   //------------------------------------------------------------
-  function playSelectedNotes() {
+  function startSelectedChord() {
     if (selectedKeys.size === 0) return;
     const freqs = [];
     selectedKeys.forEach(idx => {
       freqs.push(currentNotes[idx].freq);
     });
-    playChordFrequencies(freqs, 1.5);
+    startChordPlayback(freqs);
   }
 
   //------------------------------------------------------------
@@ -452,8 +470,16 @@
     buildKeyboard();
     generateChord();
   });
-  playGeneratedBtn.addEventListener("click", playGeneratedChord);
-  playSelectedBtn.addEventListener("click", playSelectedNotes);
+
+  playGeneratedBtn.addEventListener("pointerdown", startGeneratedChord);
+  playGeneratedBtn.addEventListener("pointerup", stopChordPlayback);
+  playGeneratedBtn.addEventListener("pointerleave", stopChordPlayback);
+  playGeneratedBtn.addEventListener("pointercancel", stopChordPlayback);
+
+  playSelectedBtn.addEventListener("pointerdown", startSelectedChord);
+  playSelectedBtn.addEventListener("pointerup", stopChordPlayback);
+  playSelectedBtn.addEventListener("pointerleave", stopChordPlayback);
+  playSelectedBtn.addEventListener("pointercancel", stopChordPlayback);
 
   // Initialize
   buildKeyboard();

--- a/chord_training.html
+++ b/chord_training.html
@@ -183,6 +183,10 @@
   let activeGain = null;
   let activeOscillators = [];
 
+  // Fade times for chord playback (seconds)
+  const FADE_IN_TIME  = 0.01;
+  const FADE_OUT_TIME = 0.3;
+
   // DOM elements
   const keyboardDiv       = document.getElementById("keyboard");
   const lowestNoteSelect  = document.getElementById("lowestNoteSelect");
@@ -373,7 +377,7 @@
     activeGain = activeAudioCtx.createGain();
     activeGain.connect(activeAudioCtx.destination);
     activeGain.gain.setValueAtTime(0, now);
-    activeGain.gain.linearRampToValueAtTime(1, now + 0.01);
+    activeGain.gain.linearRampToValueAtTime(1, now + FADE_IN_TIME);
 
     activeOscillators = [];
     frequencies.forEach(freq => {
@@ -416,9 +420,9 @@
     const now = activeAudioCtx.currentTime;
     activeGain.gain.cancelScheduledValues(now);
     activeGain.gain.setValueAtTime(activeGain.gain.value, now);
-    activeGain.gain.linearRampToValueAtTime(0, now + 0.03);
+    activeGain.gain.linearRampToValueAtTime(0, now + FADE_OUT_TIME);
     activeOscillators.forEach(osc => {
-      try { osc.stop(now + 0.03); } catch (e) {}
+      try { osc.stop(now + FADE_OUT_TIME); } catch (e) {}
     });
     setTimeout(() => {
       if (activeAudioCtx) {
@@ -427,7 +431,7 @@
         activeGain = null;
         activeOscillators = [];
       }
-    }, 60);
+    }, (FADE_OUT_TIME + 0.05) * 1000);
   }
 
   //------------------------------------------------------------

--- a/chord_training.html
+++ b/chord_training.html
@@ -179,9 +179,8 @@
   let selectedKeys = new Set();  // A set of indices that the user has selected
   let lowestChordIndex = null;   // The index (into currentNotes) of the chord's lowest note
 
-  let activeAudioCtx = null;
-  let activeGain = null;
-  let activeOscillators = [];
+  const generatedPlayback = { ctx: null, gain: null, oscillators: [] };
+  const selectedPlayback  = { ctx: null, gain: null, oscillators: [] };
 
   // Fade times for chord playback (seconds)
   const FADE_IN_TIME  = 0.01;
@@ -367,69 +366,69 @@
   //------------------------------------------------------------
   // Start/stop playback for a set of frequencies
   //------------------------------------------------------------
-  function startChordPlayback(frequencies) {
+  function startChordPlayback(state, frequencies) {
     if (!frequencies || frequencies.length === 0) return;
-    stopChordPlayback();
+    stopChordPlayback(state);
 
-    activeAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    const now = activeAudioCtx.currentTime;
+    state.ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const now = state.ctx.currentTime;
 
-    activeGain = activeAudioCtx.createGain();
-    activeGain.connect(activeAudioCtx.destination);
-    activeGain.gain.setValueAtTime(0, now);
-    activeGain.gain.linearRampToValueAtTime(1, now + FADE_IN_TIME);
+    state.gain = state.ctx.createGain();
+    state.gain.connect(state.ctx.destination);
+    state.gain.gain.setValueAtTime(0, now);
+    state.gain.gain.linearRampToValueAtTime(1, now + FADE_IN_TIME);
 
-    activeOscillators = [];
+    state.oscillators = [];
     frequencies.forEach(freq => {
-      const fGain = activeAudioCtx.createGain();
+      const fGain = state.ctx.createGain();
       fGain.gain.value = 0.12;
-      fGain.connect(activeGain);
+      fGain.connect(state.gain);
 
-      const secondGain = activeAudioCtx.createGain();
+      const secondGain = state.ctx.createGain();
       secondGain.gain.value = 0.05;
-      secondGain.connect(activeGain);
+      secondGain.connect(state.gain);
 
-      const thirdGain = activeAudioCtx.createGain();
+      const thirdGain = state.ctx.createGain();
       thirdGain.gain.value = 0.03;
-      thirdGain.connect(activeGain);
+      thirdGain.connect(state.gain);
 
-      const oscFund = activeAudioCtx.createOscillator();
+      const oscFund = state.ctx.createOscillator();
       oscFund.type = "sine";
       oscFund.frequency.value = freq;
       oscFund.connect(fGain);
       oscFund.start(now);
 
-      const osc2 = activeAudioCtx.createOscillator();
+      const osc2 = state.ctx.createOscillator();
       osc2.type = "sine";
       osc2.frequency.value = freq * 2;
       osc2.connect(secondGain);
       osc2.start(now);
 
-      const osc3 = activeAudioCtx.createOscillator();
+      const osc3 = state.ctx.createOscillator();
       osc3.type = "sine";
       osc3.frequency.value = freq * 3;
       osc3.connect(thirdGain);
       osc3.start(now);
 
-      activeOscillators.push(oscFund, osc2, osc3);
+      state.oscillators.push(oscFund, osc2, osc3);
     });
   }
 
-  function stopChordPlayback() {
-    if (!activeAudioCtx) return;
-    const now = activeAudioCtx.currentTime;
-    activeGain.gain.cancelScheduledValues(now);
-    activeGain.gain.setValueAtTime(activeGain.gain.value, now);
-    activeGain.gain.linearRampToValueAtTime(0, now + FADE_OUT_TIME);
-    activeOscillators.forEach(osc => {
+  function stopChordPlayback(state) {
+    if (!state.ctx) return;
+    const now = state.ctx.currentTime;
+    state.gain.gain.cancelScheduledValues(now);
+    state.gain.gain.setValueAtTime(state.gain.gain.value, now);
+    state.gain.gain.linearRampToValueAtTime(0, now + FADE_OUT_TIME);
+    state.oscillators.forEach(osc => {
       try { osc.stop(now + FADE_OUT_TIME); } catch (e) {}
     });
     setTimeout(() => {
-      if (activeAudioCtx) {
-        activeAudioCtx.close();
-        activeAudioCtx = null;
-        activeGain = null;
-        activeOscillators = [];
+      if (state.ctx) {
+        state.ctx.close();
+        state.ctx = null;
+        state.gain = null;
+        state.oscillators = [];
       }
     }, (FADE_OUT_TIME + 0.05) * 1000);
   }
@@ -440,7 +439,7 @@
   function startGeneratedChord() {
     if (!randomChord || randomChord.length === 0) return;
     const freqs = randomChord.map(obj => obj.freq);
-    startChordPlayback(freqs);
+    startChordPlayback(generatedPlayback, freqs);
   }
 
   //------------------------------------------------------------
@@ -452,7 +451,7 @@
     selectedKeys.forEach(idx => {
       freqs.push(currentNotes[idx].freq);
     });
-    startChordPlayback(freqs);
+    startChordPlayback(selectedPlayback, freqs);
   }
 
   //------------------------------------------------------------
@@ -476,14 +475,14 @@
   });
 
   playGeneratedBtn.addEventListener("pointerdown", startGeneratedChord);
-  playGeneratedBtn.addEventListener("pointerup", stopChordPlayback);
-  playGeneratedBtn.addEventListener("pointerleave", stopChordPlayback);
-  playGeneratedBtn.addEventListener("pointercancel", stopChordPlayback);
+  playGeneratedBtn.addEventListener("pointerup", () => stopChordPlayback(generatedPlayback));
+  playGeneratedBtn.addEventListener("pointerleave", () => stopChordPlayback(generatedPlayback));
+  playGeneratedBtn.addEventListener("pointercancel", () => stopChordPlayback(generatedPlayback));
 
   playSelectedBtn.addEventListener("pointerdown", startSelectedChord);
-  playSelectedBtn.addEventListener("pointerup", stopChordPlayback);
-  playSelectedBtn.addEventListener("pointerleave", stopChordPlayback);
-  playSelectedBtn.addEventListener("pointercancel", stopChordPlayback);
+  playSelectedBtn.addEventListener("pointerup", () => stopChordPlayback(selectedPlayback));
+  playSelectedBtn.addEventListener("pointerleave", () => stopChordPlayback(selectedPlayback));
+  playSelectedBtn.addEventListener("pointercancel", () => stopChordPlayback(selectedPlayback));
 
   // Initialize
   buildKeyboard();


### PR DESCRIPTION
## Summary
- allow holding the play buttons to sustain chords
- create start/stop playback helpers
- update event listeners to use pointer events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68590df3cb2c8333acdc0c2f25a46ba3