### PR TITLE
Improve mobile experience for chord practice

### DIFF
--- a/chord_training.html
+++ b/chord_training.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Chord Practice</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <style>
@@ -14,6 +15,9 @@
     }
     #keyboard {
       white-space: nowrap;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      padding-bottom: 10px;
     }
     .key {
       display: inline-block;
@@ -23,6 +27,7 @@
       border: 1px solid #666;
       margin: 0;
       cursor: pointer; /* so user sees clickable */
+      overflow: hidden; /* keep markers inside */
     }
     /* White keys: aligned at bottom */
     .white-key {
@@ -66,6 +71,35 @@
       border-radius: 50%;
       background-color: #84ff84; /* greenish */
     }
+
+    @media (max-width: 576px) {
+      .white-key {
+        width: 40px;
+        height: 170px;
+      }
+      .black-key {
+        width: 25px;
+        height: 110px;
+        margin: 0 -12px;
+      }
+      h1 {
+        font-size: 1.5rem;
+      }
+      .lowest-note-marker,
+      .selected-note-marker {
+        width: 20px;
+        height: 20px;
+        bottom: 4px;
+      }
+      .control-buttons .btn {
+        display: block;
+        width: 100%;
+        margin-bottom: 0.5rem;
+      }
+      .control-buttons .btn:last-child {
+        margin-bottom: 0;
+      }
+    }
   </style>
 </head>
 <body class="bg-dark text-light">
@@ -93,7 +127,7 @@
     </div>
   </div>
 
-  <div class="mb-4">
+  <div class="mb-4 control-buttons">
     <button id="nextBtn" class="btn btn-primary me-2">Next</button>
     <button id="playGeneratedBtn" class="btn btn-success me-2">Play Generated Chord</button>
     <button id="playSelectedBtn" class="btn btn-success">Play Selected Notes</button>


### PR DESCRIPTION
## Summary
- keep note markers within key borders
- stack and widen buttons on small screens
- shrink markers for narrow keys

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a5c240d608333acc0d68ca3a3b0ec