### PR TITLE
Add index page for ear training apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <title>Ear Training</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <style>
+    body {
+      background-color: #343a40;
+      color: #fff;
+      font-family: sans-serif;
+      margin: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+    }
+    .app-list {
+      width: 100%;
+      max-width: 400px;
+    }
+    .app-btn {
+      margin-bottom: 1rem;
+    }
+  </style>
+</head>
+<body class="bg-dark text-light">
+  <div class="container text-center app-list">
+    <h1 class="mb-4">Ear Training Apps</h1>
+    <a href="chord_training.html" class="btn btn-primary w-100 app-btn">Chord Training</a>
+    <a href="melody_training.html" class="btn btn-primary w-100 app-btn">Melody Training</a>
+    <a href="sight_singing.html" class="btn btn-primary w-100 app-btn">Sight-Singing</a>
+    <a href="tuning_training.html" class="btn btn-primary w-100">Tuning Training</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with dark theme and bootstrap styling
- link to chord, melody, sight-singing, and tuning training pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a6c97688c833398bd2a835c8cad5b