### PR TITLE
Add simple reverb support

### DIFF
--- a/chord_training.html
+++ b/chord_training.html
@@ -61,8 +61,8 @@
   let selectedKeys = new Set();
   let lowestChordIndex = null;
 
-  const generatedPlayback = new Sound.ChordPlayer({attack:0.3, release:0.7});
-  const selectedPlayback  = new Sound.ChordPlayer({attack:0.3, release:0.7});
+  const generatedPlayback = new Sound.ChordPlayer({attack:0.3, release:0.7, reverbWet:0.25});
+  const selectedPlayback  = new Sound.ChordPlayer({attack:0.3, release:0.7, reverbWet:0.25});
 
   const keyboardDiv       = document.getElementById("keyboard");
   const lowestNoteSelect  = document.getElementById("lowestNoteSelect");

--- a/melody_training.html
+++ b/melody_training.html
@@ -70,7 +70,8 @@
   populateNoteSelects(ALL_NOTES, lowestNoteSelect, highestNoteSelect, "C3", "C5");
 
   const player = new Sound.SequencePlayer({
-    overtoneAmps: [0.20, 0.10, 0.05, 0.03]
+    overtoneAmps: [0.20, 0.10, 0.05, 0.03],
+    reverbWet: 0.25
   });
 
   //-----------------------------------------------------------

--- a/sight_singing.html
+++ b/sight_singing.html
@@ -61,7 +61,7 @@
 
   populateNoteSelects(ALL_NOTES, lowestNoteSelect, highestNoteSelect, "C3", "C5");
 
-  const player = new Sound.SequencePlayer();
+  const player = new Sound.SequencePlayer({reverbWet:0.25});
 
   // ------------------------------------------------------------
   // 2) Build the keyboard for the chosen range

--- a/sound.js
+++ b/sound.js
@@ -49,6 +49,9 @@
         this._playOne(ctx,f,t,dur,convolver);
         t += dur + gap;
       });
+      const endTime=t-gap;
+      const extra=this.reverbWet>0?this.reverbSeconds:0;
+      setTimeout(()=>{try{ctx.close();}catch(e){}},(endTime-ctx.currentTime+extra+0.05)*1000);
     }
     _playOne(ctx,freq,start,dur,convolver){
       const stop=start+dur;
@@ -120,11 +123,12 @@
       this.gain.gain.exponentialRampToValueAtTime(0.0001,n+this.release);
       if(this.stopTimeout) clearTimeout(this.stopTimeout);
       const ctx=this.ctx, oscs=this.oscillators;
+      const extra=this.reverbWet>0?this.reverbSeconds:0;
       this.stopTimeout=setTimeout(()=>{
         oscs.forEach(o=>{try{o.stop();}catch(e){}});
         try{ctx.close();}catch(e){}
         if(this.ctx===ctx){this.ctx=null;this.gain=null;this.oscillators=[];this.reverbNode=null;this.wetGain=null;}
-        this.stopTimeout=null;this.isFadingOut=false;},(this.release+0.05)*1000);
+        this.stopTimeout=null;this.isFadingOut=false;},(this.release+extra+0.05)*1000);
     }
   }
 

--- a/sound.js
+++ b/sound.js
@@ -10,25 +10,53 @@
     return o;
   }
 
+  function createReverb(ctx, seconds=2, decay=2){
+    const length = ctx.sampleRate * seconds;
+    const impulse = ctx.createBuffer(2, length, ctx.sampleRate);
+    for(let c=0;c<impulse.numberOfChannels;c++){
+      const data = impulse.getChannelData(c);
+      for(let i=0;i<length;i++){
+        data[i] = (Math.random()*2-1) * Math.pow(1 - i/length, decay);
+      }
+    }
+    const convolver = ctx.createConvolver();
+    convolver.buffer = impulse;
+    return convolver;
+  }
+
   class SequencePlayer {
     constructor(opts={}){
       this.attack = opts.attack || 0.01;
       this.release = opts.release || 0.01;
       this.overtoneAmps = opts.overtoneAmps || [0.12,0.05,0.03];
+      this.reverbWet = opts.reverbWet || 0;
+      this.reverbSeconds = opts.reverbSeconds || 2;
+      this.reverbDecay = opts.reverbDecay || 2;
     }
     playSequence(freqs, dur=0.8, gap=0.1){
       if(!freqs || !freqs.length) return;
       const ctx = new (window.AudioContext||window.webkitAudioContext)();
+      const convolver = this.reverbWet>0 ? createReverb(ctx,this.reverbSeconds,this.reverbDecay) : null;
+      let wetGain=null;
+      if(convolver){
+        wetGain=ctx.createGain();
+        wetGain.gain.value=this.reverbWet;
+        convolver.connect(wetGain);
+        wetGain.connect(ctx.destination);
+      }
       let t = ctx.currentTime;
       freqs.forEach(f=>{
-        this._playOne(ctx,f,t,dur);
+        this._playOne(ctx,f,t,dur,convolver);
         t += dur + gap;
       });
     }
-    _playOne(ctx,freq,start,dur){
+    _playOne(ctx,freq,start,dur,convolver){
       const stop=start+dur;
       const main=ctx.createGain();
       main.connect(ctx.destination);
+      if(convolver){
+        main.connect(convolver);
+      }
       main.gain.setValueAtTime(0,start);
       main.gain.linearRampToValueAtTime(1,start+this.attack);
       main.gain.linearRampToValueAtTime(0,stop-this.release);
@@ -42,7 +70,11 @@
       this.attack = opts.attack || 0.3;
       this.release = opts.release || 0.7;
       this.overtoneAmps = opts.overtoneAmps || [0.12,0.05,0.03];
+      this.reverbWet = opts.reverbWet || 0;
+      this.reverbSeconds = opts.reverbSeconds || 2;
+      this.reverbDecay = opts.reverbDecay || 2;
       this.ctx=null;this.gain=null;this.oscillators=[];this.stopTimeout=null;this.isFadingOut=false;
+      this.reverbNode=null;this.wetGain=null;
     }
     start(freqs){
       if(!freqs || !freqs.length) return;
@@ -60,6 +92,14 @@
       const n=this.ctx.currentTime;
       this.gain=this.ctx.createGain();
       this.gain.connect(this.ctx.destination);
+      if(this.reverbWet>0){
+        this.reverbNode=createReverb(this.ctx,this.reverbSeconds,this.reverbDecay);
+        this.wetGain=this.ctx.createGain();
+        this.wetGain.gain.value=this.reverbWet;
+        this.reverbNode.connect(this.wetGain);
+        this.wetGain.connect(this.ctx.destination);
+        this.gain.connect(this.reverbNode);
+      }
       this.gain.gain.setValueAtTime(0.0001,n);
       this.gain.gain.exponentialRampToValueAtTime(1,n+this.attack);
       this.oscillators=[];
@@ -79,11 +119,11 @@
       this.gain.gain.setValueAtTime(this.gain.gain.value,n);
       this.gain.gain.exponentialRampToValueAtTime(0.0001,n+this.release);
       if(this.stopTimeout) clearTimeout(this.stopTimeout);
-      const ctx=this.ctx, oscs=this.oscillators; 
+      const ctx=this.ctx, oscs=this.oscillators;
       this.stopTimeout=setTimeout(()=>{
         oscs.forEach(o=>{try{o.stop();}catch(e){}});
         try{ctx.close();}catch(e){}
-        if(this.ctx===ctx){this.ctx=null;this.gain=null;this.oscillators=[];}
+        if(this.ctx===ctx){this.ctx=null;this.gain=null;this.oscillators=[];this.reverbNode=null;this.wetGain=null;}
         this.stopTimeout=null;this.isFadingOut=false;},(this.release+0.05)*1000);
     }
   }


### PR DESCRIPTION
## Summary
- create a basic convolution reverb effect
- support reverb in `SequencePlayer` and `ChordPlayer`
- enable reverb in chord, melody, and sight-singing pages

## Testing
- `npm test` *(fails: package.json missing)*
- `node -e "new Function(require('fs').readFileSync('sound.js','utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_685b78a16b20833392dfceba99783731