### PR TITLE
Fix piano key spacing and add rounded bottoms

### DIFF
--- a/common.css
+++ b/common.css
@@ -32,6 +32,8 @@ body {
   background: #fff;
   vertical-align: bottom;
   z-index: 1;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .black-key {
@@ -41,12 +43,14 @@ body {
   color: #fff;
   vertical-align: top;
   z-index: 2;
-  margin: 0 -18px;
+  margin: 0 -19px;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 @media (max-width: 576px) {
   .white-key { width: 40px; height: 170px; }
-  .black-key { width: 25px; height: 110px; margin: 0 -12px; }
+  .black-key { width: 25px; height: 110px; margin: 0 -12.5px; }
   h1 { font-size: 1.5rem; }
   .control-buttons .btn {
     display: block;


### PR DESCRIPTION
## Summary
- round bottom borders of piano keys
- adjust black key margins so white keys line up

## Testing
- `git show -U0`


------
https://chatgpt.com/codex/tasks/task_e_685b848d8aa08333a80244d5f020df47