### PR TITLE
Refactor ChordPlayer to keep an oscillator pool

### DIFF
--- a/sound.js
+++ b/sound.js
@@ -122,7 +122,6 @@
       this.wetGain = null;
       this.currentFreqs = null;
 
-      this._setupContext();
     }
 
     _setupContext() {
@@ -214,6 +213,8 @@
 
       if (!this.context) {
         this._setupContext();
+      } else if (this.context.state === 'suspended') {
+        this.context.resume();
       }
 
       const same =

--- a/sound.js
+++ b/sound.js
@@ -297,7 +297,7 @@
         arr.forEach((gain) => {
           gain.gain.cancelScheduledValues(now);
           gain.gain.setValueAtTime(gain.gain.value, now);
-          gain.gain.exponentialRampToValueAtTime(0, now + this.release);
+          gain.gain.exponentialRampToValueAtTime(0.0001, now + this.release);
         });
       });
 

--- a/sound.js
+++ b/sound.js
@@ -296,8 +296,13 @@
       this.noteGains.forEach((arr) => {
         arr.forEach((gain) => {
           gain.gain.cancelScheduledValues(now);
-          gain.gain.setValueAtTime(gain.gain.value, now);
-          gain.gain.exponentialRampToValueAtTime(0.0001, now + this.release);
+          const value = gain.gain.value;
+          if (value > 0) {
+            gain.gain.setValueAtTime(value, now);
+            gain.gain.exponentialRampToValueAtTime(0.0001, now + this.release);
+          } else {
+            gain.gain.setValueAtTime(0, now);
+          }
         });
       });
 

--- a/sound.js
+++ b/sound.js
@@ -246,6 +246,16 @@
           this.gain.gain.cancelScheduledValues(now);
           this.gain.gain.setValueAtTime(Math.max(this.gain.gain.value, 0.0001), now);
           this.gain.gain.exponentialRampToValueAtTime(1, now + this.attack);
+
+          frequencies.forEach((freq) => {
+            const idx = this._findFreqIndex(freq);
+            if (idx !== -1) {
+              this.noteGains[idx].forEach((gain, i) => {
+                gain.gain.cancelScheduledValues(now);
+                gain.gain.setValueAtTime(this.overtoneAmps[i], now);
+              });
+            }
+          });
         }
       } else {
         this.noteGains.forEach((arr) => {

--- a/sound.js
+++ b/sound.js
@@ -114,7 +114,6 @@
       this.gain = null;
       this.noteFreqs = [];
       this.noteGains = [];
-      this.noteOscillators = [];
       this._freqTol = 1e-2; // frequency matching tolerance
       this.stopTimeout = null;
       this.isFadingOut = false;
@@ -146,7 +145,6 @@
         this.noteFreqs.push(freq);
 
         const gains = [];
-        const oscs = [];
         this.overtoneAmps.forEach((amp, idx) => {
           const gain = this.context.createGain();
           gain.gain.value = 0;
@@ -159,11 +157,10 @@
           osc.start();
 
           gains.push(gain);
-          oscs.push(osc);
+          // oscillator reference isn't stored; it will keep running as part of the graph
         });
 
         this.noteGains.push(gains);
-        this.noteOscillators.push(oscs);
       }
 
       this.gain.gain.setValueAtTime(0.0001, this.context.currentTime);
@@ -178,43 +175,6 @@
       return -1;
     }
 
-    _immediateCleanup() {
-      if (!this.context) {
-        return;
-      }
-
-      if (this.stopTimeout) {
-        clearTimeout(this.stopTimeout);
-        this.stopTimeout = null;
-      }
-
-      this.noteOscillators.forEach((arr) => {
-        arr.forEach((osc) => {
-          try {
-            osc.stop();
-          } catch (err) {
-            // ignore
-          }
-        });
-      });
-
-      const context = this.context;
-      try {
-        context.close();
-      } catch (err) {
-        // ignore
-      }
-
-      this.context = null;
-      this.gain = null;
-      this.noteFreqs = [];
-      this.noteGains = [];
-      this.noteOscillators = [];
-      this.reverbNode = null;
-      this.wetGain = null;
-      this.isFadingOut = false;
-      this.currentFreqs = null;
-    }
 
     start(frequencies) {
       if (!frequencies || frequencies.length === 0) {

--- a/sound.js
+++ b/sound.js
@@ -115,6 +115,7 @@
       this.noteFreqs = [];
       this.noteGains = [];
       this.noteOscillators = [];
+      this._freqTol = 1e-2; // frequency matching tolerance
       this.stopTimeout = null;
       this.isFadingOut = false;
 
@@ -166,6 +167,15 @@
       }
 
       this.gain.gain.setValueAtTime(0.0001, this.context.currentTime);
+    }
+
+    _findFreqIndex(frequency) {
+      for (let i = 0; i < this.noteFreqs.length; i++) {
+        if (Math.abs(this.noteFreqs[i] - frequency) < this._freqTol) {
+          return i;
+        }
+      }
+      return -1;
     }
 
     _immediateCleanup() {
@@ -220,7 +230,9 @@
       const same =
         this.currentFreqs &&
         this.currentFreqs.length === frequencies.length &&
-        this.currentFreqs.every((freq, index) => freq === frequencies[index]);
+        this.currentFreqs.every(
+          (freq, index) => Math.abs(freq - frequencies[index]) < this._freqTol
+        );
 
       const now = this.context.currentTime;
 
@@ -244,7 +256,7 @@
         });
 
         frequencies.forEach((frequency) => {
-          const idx = this.noteFreqs.indexOf(frequency);
+          const idx = this._findFreqIndex(frequency);
           if (idx !== -1) {
             this.noteGains[idx].forEach((gain, i) => {
               gain.gain.setValueAtTime(this.overtoneAmps[i], now);


### PR DESCRIPTION
## Summary
- create `_setupContext` to build a single AudioContext with oscillators for every note
- reuse the oscillator pool in `start()` instead of rebuilding nodes
- update `stop()` to ramp note gains to silence without closing the context

## Testing
- `node -c sound.js`

------
https://chatgpt.com/codex/tasks/task_e_685c1460bcbc833398f38a3cbf9bbb18