### PR TITLE
Fix hover state on piano keys for touch devices

### DIFF
--- a/common.css
+++ b/common.css
@@ -37,7 +37,7 @@ body {
   border-bottom-right-radius: 4px;
 }
 
-.white-key:hover {
+.white-key.hover {
   background: #e6e6e6;
 }
 
@@ -53,7 +53,7 @@ body {
   border-bottom-right-radius: 4px;
 }
 
-.black-key:hover {
+.black-key.hover {
   background: #373737;
 }
 

--- a/common.js
+++ b/common.js
@@ -37,6 +37,15 @@ function renderKeyboard(notes, container, onClick) {
     if (n.name.includes("#")) div.classList.add("black-key");
     else div.classList.add("white-key");
     if (onClick) div.addEventListener("click", () => onClick(i));
+
+    const addHover = () => div.classList.add("hover");
+    const removeHover = () => div.classList.remove("hover");
+    div.addEventListener("pointerenter", addHover);
+    div.addEventListener("pointerleave", removeHover);
+    div.addEventListener("pointerdown", addHover);
+    ["pointerup", "pointercancel"].forEach(evt =>
+      div.addEventListener(evt, removeHover)
+    );
     container.appendChild(div);
     keys.push(div);
   });


### PR DESCRIPTION
## Summary
- remove CSS `:hover` pseudoclasses
- add `.hover` class styles
- toggle `.hover` class via pointer events in `renderKeyboard`

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d145770448333877c514b33096008