### PR TITLE
Add reusable menu

### DIFF
--- a/chord_training.html
+++ b/chord_training.html
@@ -269,6 +269,7 @@
   buildKeyboard();
   generateChord();
 </script>
+<script src="menu.js"></script>
 
 </body>
 </html>

--- a/common.css
+++ b/common.css
@@ -70,3 +70,40 @@ body {
     margin-bottom: 0;
   }
 }
+.app-menu {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+}
+.app-menu button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+}
+.app-menu .menu-links {
+  display: none;
+  position: absolute;
+  right: 0;
+  background-color: #343a40;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 0.5rem;
+}
+.app-menu .menu-links a {
+  color: #fff;
+  text-decoration: none;
+  display: block;
+  padding: 0.25rem 0;
+}
+.app-menu .menu-links a:hover {
+  text-decoration: underline;
+}
+.app-menu.open .menu-links {
+  display: block;
+}
+@media (max-width: 576px) {
+  .app-menu button { font-size: 2rem; }
+  .app-menu .menu-links { font-size: 1.2rem; }
+}

--- a/melody_training.html
+++ b/melody_training.html
@@ -245,6 +245,7 @@
   buildKeyboard();
   generateRandomMelody();
 </script>
+<script src="menu.js"></script>
 
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const menu = document.createElement('div');
+  menu.className = 'app-menu';
+
+  const toggle = document.createElement('button');
+  toggle.id = 'menuToggle';
+  toggle.innerHTML = '&#9776;';
+  menu.appendChild(toggle);
+
+  const links = document.createElement('div');
+  links.className = 'menu-links';
+  links.innerHTML = `
+    <a href="index.html">Home</a>
+    <a href="chord_training.html">Chords</a>
+    <a href="melody_training.html">Melody</a>
+    <a href="sight_singing.html">Sight-Singing</a>
+    <a href="tuning_training.html">Intonation</a>
+  `;
+  menu.appendChild(links);
+
+  toggle.addEventListener('click', () => {
+    menu.classList.toggle('open');
+  });
+
+  document.addEventListener('click', e => {
+    if (!menu.contains(e.target)) {
+      menu.classList.remove('open');
+    }
+  });
+
+  document.body.appendChild(menu);
+});

--- a/sight_singing.html
+++ b/sight_singing.html
@@ -160,6 +160,7 @@
   buildKeyboard();
   generateSequence();
 </script>
+<script src="menu.js"></script>
 
 </body>
 </html>

--- a/tuning_training.html
+++ b/tuning_training.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>Intonation Practice</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="common.css">
   <style>
     body {
       background-color: #343a40;
@@ -592,6 +593,7 @@ function pickNewInterval() {
   }
 }
 </script>
+<script src="menu.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a common hamburger menu via `menu.js`
- style the menu in `common.css`
- load the menu on all practice pages
- include `common.css` on tuning page for menu styles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e4336beac83339073d603b49744fc