### PR TITLE
Add chromatic run to intonation training

### DIFF
--- a/tuning_training.html
+++ b/tuning_training.html
@@ -117,6 +117,7 @@
     <div id="resultsList"></div>
   </div>
 </div>
+<script src="sound.js"></script>
 <script>
 /*
  * Configuration
@@ -253,6 +254,9 @@ const resultsList         = document.getElementById("resultsList");
 // Flag to reveal controls on first interval
 let controlsShown = false;
 
+// SequencePlayer for quick chromatic runs
+const chromaticPlayer = new Sound.SequencePlayer({attack:0.01, release:0.05});
+
 /***************************************************************
  * AUDIO SETUP ON DEMAND
  ***************************************************************/
@@ -329,6 +333,7 @@ newIntervalBtn.addEventListener("click", async () => {
   }
   await initAudioIfNeeded();
   pickNewInterval();
+  playChromaticRun();
 });
 
 /***************************************************************
@@ -658,6 +663,15 @@ function pickNewInterval() {
     updateMarkerPosition();
     updateCentsDifference();
   }
+}
+
+// Play a quick chromatic run from the low tone to the high tone
+function playChromaticRun() {
+  const freqs = [];
+  for (let i = 0; i <= currentSemitones; i++) {
+    freqs.push(rootFreq * Math.pow(2, i / 12));
+  }
+  chromaticPlayer.playSequence(freqs, 0.1, 0.02);
 }
 </script>
 <script src="menu.js"></script>

--- a/tuning_training.html
+++ b/tuning_training.html
@@ -253,6 +253,8 @@ const resultsList         = document.getElementById("resultsList");
 
 // Flag to reveal controls on first interval
 let controlsShown = false;
+// Tracks whether a previous interval exists
+let hasInterval = false;
 
 // SequencePlayer for quick chromatic runs
 const chromaticPlayer = new Sound.SequencePlayer({attack:0.01, release:0.05});
@@ -332,8 +334,11 @@ newIntervalBtn.addEventListener("click", async () => {
     sliderContainer.style.display = "";
   }
   await initAudioIfNeeded();
+  if (hasInterval) {
+    playChromaticRun();
+  }
   pickNewInterval();
-  playChromaticRun();
+  hasInterval = true;
 });
 
 /***************************************************************
@@ -671,7 +676,7 @@ function playChromaticRun() {
   for (let i = 0; i <= currentSemitones; i++) {
     freqs.push(rootFreq * Math.pow(2, i / 12));
   }
-  chromaticPlayer.playSequence(freqs, 0.1, 0.02);
+  chromaticPlayer.playSequence(freqs, 0.05, 0.01);
 }
 </script>
 <script src="menu.js"></script>


### PR DESCRIPTION
## Summary
- load `sound.js` on the intonation page
- set up `SequencePlayer` for short note sequences
- play a fast chromatic run when a new interval is generated

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e8a558650833398d8b2b7c0f707b4