### PR TITLE
Move chord options to collapsible panel

### DIFF
--- a/chord_training.html
+++ b/chord_training.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <title>Chord Practice</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link rel="stylesheet" href="common.css">
   <style>
     .key{cursor:pointer;}
@@ -19,7 +20,21 @@
 <div class="container py-4">
   <h1 class="text-center mb-4">Chord Practice</h1>
 
-  <div class="row g-3 align-items-end mb-4">
+
+  <div class="mb-4 control-buttons">
+    <button id="nextBtn" class="btn btn-primary me-2">New Chord</button>
+    <button id="playGeneratedBtn" class="btn btn-success me-2">Play Chord</button>
+    <button id="playSelectedBtn" class="btn btn-success">Play Selection</button>
+  </div>
+
+  <div id="keyboard" class="mb-3"></div>
+
+  <div class="text-center mb-2">
+    <button id="optionsToggleBtn" class="btn btn-secondary">
+      <i class="fa-solid fa-angle-down"></i>
+    </button>
+  </div>
+  <div id="optionsPanel" class="row g-3 align-items-end mb-4 d-none">
     <div class="col-md-4">
       <label for="lowestNoteSelect" class="form-label">Lowest Note</label>
       <select id="lowestNoteSelect" class="form-select form-select-sm"></select>
@@ -39,14 +54,6 @@
       </select>
     </div>
   </div>
-
-  <div class="mb-4 control-buttons">
-    <button id="nextBtn" class="btn btn-primary me-2">New Chord</button>
-    <button id="playGeneratedBtn" class="btn btn-success me-2">Play Chord</button>
-    <button id="playSelectedBtn" class="btn btn-success">Play Selection</button>
-  </div>
-
-  <div id="keyboard" class="mb-3"></div>
 </div>
 
 <script src="common.js"></script>
@@ -72,6 +79,8 @@
   const nextBtn           = document.getElementById("nextBtn");
   const playGeneratedBtn  = document.getElementById("playGeneratedBtn");
   const playSelectedBtn   = document.getElementById("playSelectedBtn");
+  const optionsPanel      = document.getElementById("optionsPanel");
+  const optionsToggleBtn  = document.getElementById("optionsToggleBtn");
 
   populateNoteSelects(ALL_NOTES, lowestNoteSelect, highestNoteSelect, "C3", "C5");
 
@@ -254,6 +263,18 @@
   highestNoteSelect.addEventListener("change", refreshChord);
   numNotesSelect.addEventListener("change", generateChord);
   nextBtn.addEventListener("click", onNextChord);
+
+  optionsToggleBtn.addEventListener("click", () => {
+    optionsPanel.classList.toggle("d-none");
+    const icon = optionsToggleBtn.querySelector("i");
+    if (optionsPanel.classList.contains("d-none")) {
+      icon.classList.remove("fa-angle-up");
+      icon.classList.add("fa-angle-down");
+    } else {
+      icon.classList.remove("fa-angle-down");
+      icon.classList.add("fa-angle-up");
+    }
+  });
 
   function setupPlaybackButton(btn, startFn, player) {
     btn.addEventListener("pointerdown", startFn);


### PR DESCRIPTION
## Summary
- add Font Awesome for new toggle icons
- move chord settings to bottom of page and hide them by default
- add arrow button to reveal or hide the settings

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed206d3088333bd2741aa7b129a7c