### PR TITLE
Move controls to bottom on mobile

### DIFF
--- a/chord_training.html
+++ b/chord_training.html
@@ -19,8 +19,8 @@
   </style>
 </head>
 <body class="bg-dark text-light">
-<div class="container py-4">
-  <h1 class="text-center mb-4">Chord Practice</h1>
+  <h1 class="text-center my-3">Chord Practice</h1>
+  <div class="container py-4 mobile-bottom">
 
 
   <div class="mb-4 control-buttons">

--- a/common.css
+++ b/common.css
@@ -107,3 +107,13 @@ body {
   .app-menu button { font-size: 2rem; }
   .app-menu .menu-links { font-size: 1.2rem; }
 }
+@media (max-width: 576px) {
+  body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+  .mobile-bottom {
+    margin-top: auto;
+  }
+}

--- a/melody_training.html
+++ b/melody_training.html
@@ -18,8 +18,8 @@
   </style>
 </head>
 <body class="bg-dark text-light">
-<div class="container py-4">
-  <h1 class="text-center mb-4">Melody Practice</h1>
+  <h1 class="text-center my-3">Melody Practice</h1>
+  <div class="container py-4 mobile-bottom">
 
 
   <div class="mb-4 control-buttons">

--- a/sight_singing.html
+++ b/sight_singing.html
@@ -17,8 +17,8 @@
   </style>
 </head>
 <body class="bg-dark text-light">
-<div class="container py-4">
-  <h1 class="text-center mb-4">Sight-Singing Practice</h1>
+  <h1 class="text-center my-3">Sight-Singing Practice</h1>
+  <div class="container py-4 mobile-bottom">
 
 
   <div class="mb-4 control-buttons">


### PR DESCRIPTION
## Summary
- make the app body flexible on small screens
- push main content to the bottom with `.mobile-bottom`
- adjust markup of chord, melody and sight-singing pages

## Testing
- `tidy -qe chord_training.html`
- `tidy -qe melody_training.html`
- `tidy -qe sight_singing.html`


------
https://chatgpt.com/codex/tasks/task_e_685ee075f1f88333bf05a731f6759c2b