### PR TITLE
Fix mobile layout, round cent feedback

### DIFF
--- a/common.css
+++ b/common.css
@@ -69,6 +69,10 @@ body {
   .control-buttons .btn:last-child {
     margin-bottom: 0;
   }
+  /* Extra space below button stack so the last button isn't clipped */
+  .control-buttons {
+    margin-bottom: 2rem;
+  }
 }
 .app-menu {
   position: fixed;

--- a/tuning_training.html
+++ b/tuning_training.html
@@ -522,10 +522,11 @@ function updateMarkerPosition() {
 function updateCentsDifference(diffOverride = null) {
   const centDiff = diffOverride !== null ? diffOverride : getCurrentDifference();
   let diffText = "0 cents";
+  const rounded = Math.round(Math.abs(centDiff));
   if (centDiff > 0) {
-    diffText = `${Math.abs(centDiff).toFixed(1)} cents sharp`;
+    diffText = `${rounded} cents sharp`;
   } else if (centDiff < 0) {
-    diffText = `${Math.abs(centDiff).toFixed(1)} cents flat`;
+    diffText = `${rounded} cents flat`;
   }
   intervalDisplay.textContent = `${intervalName} (${diffText})`;
 }


### PR DESCRIPTION
## Summary
- add extra margin to mobile control buttons so the last one doesn't get clipped
- round cents feedback to the nearest cent in tuning training

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f6eec31088333b3a636a0ecadbf15