### PR TITLE
Fix mobile button darkening

### DIFF
--- a/common.css
+++ b/common.css
@@ -128,16 +128,17 @@ body {
 
 /* Remove persistent darkening on touch devices */
 button, .btn {
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
-.btn:focus {
+.btn:focus,
+.btn:focus-visible {
   box-shadow: none !important;
 }
 
 .btn:active:not(.active) {
-  color: var(--bs-btn-color);
-  background-color: var(--bs-btn-bg);
-  border-color: var(--bs-btn-border-color);
-  box-shadow: none;
+  color: var(--bs-btn-color) !important;
+  background-color: var(--bs-btn-bg) !important;
+  border-color: var(--bs-btn-border-color) !important;
+  box-shadow: none !important;
 }

--- a/common.css
+++ b/common.css
@@ -125,3 +125,19 @@ body {
     height: 3rem;
   }
 }
+
+/* Remove persistent darkening on touch devices */
+button, .btn {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.btn:focus {
+  box-shadow: none !important;
+}
+
+.btn:active:not(.active) {
+  color: var(--bs-btn-color);
+  background-color: var(--bs-btn-bg);
+  border-color: var(--bs-btn-border-color);
+  box-shadow: none;
+}


### PR DESCRIPTION
## Summary
- avoid the darkened "recently pressed" look on mobile buttons by overriding Bootstrap active styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f721403008333a7d9f69756864d7f