### PR TITLE
Add live cent readout when adjusting slider post-check

### DIFF
--- a/tuning_training.html
+++ b/tuning_training.html
@@ -623,12 +623,14 @@ function updateMarkerPosition() {
 // Show how many cents away the user is from the correct pitch
 function updateCentsDifference(diffOverride = null) {
   const centDiff = diffOverride !== null ? diffOverride : getCurrentDifference();
-  let diffText = "0 cents";
   const rounded = Math.round(Math.abs(centDiff));
-  if (centDiff > 0) {
-    diffText = `${rounded} cents sharp`;
-  } else if (centDiff < 0) {
-    diffText = `${rounded} cents flat`;
+  let diffText = "0 cents";
+  if (rounded !== 0) {
+    if (centDiff > 0) {
+      diffText = `${rounded} cents sharp`;
+    } else if (centDiff < 0) {
+      diffText = `${rounded} cents flat`;
+    }
   }
   intervalDisplay.textContent = `${intervalName} (${diffText})`;
 }

--- a/tuning_training.html
+++ b/tuning_training.html
@@ -22,6 +22,7 @@
     }
     #intervalDisplay {
       font-size: 1.2em;
+      text-align: center;
     }
     #sliderContainer {
       position: relative;

--- a/tuning_training.html
+++ b/tuning_training.html
@@ -477,6 +477,9 @@ pitchSlider.addEventListener("input", () => {
     const val = parseFloat(pitchSlider.value);
     const freq = sliderValueToFrequency(val);
     userOsc.frequency.setValueAtTime(freq, audioCtx.currentTime);
+    if (checkVisible) {
+      updateCentsDifference();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- improve tuning training slider feedback
- while in post-check mode, update the cents difference live as the slider moves

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860eed074148333b9308621cbaab43b